### PR TITLE
Update package.json with latest esm-seedrandom

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "color-generator"
   ],
   "dependencies": {
-    "esm-seedrandom": "^3.0.5-esm.2"
+    "esm-seedrandom": "3.0.5-esm.2"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",


### PR DESCRIPTION
the reason to do this because, Semantic Versioning (SemVer) treats "prerelease tags".The package manager views these two versions on a timeline. The rule is that a stable version is always "newer" or "greater" than its corresponding prerelease version. Since the stable version 3.0.5 exists on the registry, and it is technically "greater" than 3.0.5-esm.2, Yarn picks 3.0.5 because, tt satisfies the range and package managers prefer stable releases over prereleases whenever possible